### PR TITLE
Fixed typographical error, changed archetecture to architecture in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Peachy Printer and it software are community driven, Please send us a pull reque
 In order to be considered please ensure that:
 + Test Driven Design (TDD) write your tests first then write the code to make them work.
 + Respect the Single Responsibility Principal
-+ Follow Onion Archetecture Principals
++ Follow Onion Architecture Principals
 + PEP8 formatting [Excpeting line length(E501) we are not programming on terminals anymore]
 
 Please be aware that by contributing you agree to assignment of your copyrite to Peachy Printer INC. We do this for logistics and managment we will respect you freedoms and keep this source open.


### PR DESCRIPTION
@PeachyPrinter, I've corrected a typographical error in the documentation of the [peachyprintertools](https://github.com/PeachyPrinter/peachyprintertools) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
